### PR TITLE
New Naming Convention

### DIFF
--- a/src/main/java/de/worldiety/autocd/Main.java
+++ b/src/main/java/de/worldiety/autocd/Main.java
@@ -212,16 +212,14 @@ public class Main {
     }
 
     /**
-     * Creates a name for a depending service out of the project name and a hashed registry image path from the main service
+     * Creates a name for a depending service
      *
      * @param main
      * @param other
      */
     private static void setServiceNameForOtherImages(AutoCD main, AutoCD other) {
         if (other.getServiceName() == null) {
-            other.setServiceName(Util.hash(
-                    System.getenv(Environment.CI_PROJECT_NAME.toString()) + main.getIdentifierRegistryImagePath()).substring(0, 20)
-            );
+            other.setServiceName(Util.slugify(main.getServiceName() + "-" + main.getIdentifierRegistryImagePath()));
         }
     }
 

--- a/src/main/java/de/worldiety/autocd/k8s/K8sClient.java
+++ b/src/main/java/de/worldiety/autocd/k8s/K8sClient.java
@@ -695,7 +695,14 @@ public class K8sClient {
             return autoCD.getServiceName();
         }
 
-        return Util.slugify("service--" + getName());
+        String serviceName = "service--" + getName();
+
+        // Validate the length of the new service name - should be less then 63 characters:
+        // https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/discovery/types.go#L122-L130
+        if (serviceName.length() > 63) {
+            throw new IllegalArgumentException("The service name MUST NOT have more then 63 characters!");
+        }
+        return serviceName;
     }
 
     @NotNull

--- a/src/main/java/de/worldiety/autocd/k8s/K8sClient.java
+++ b/src/main/java/de/worldiety/autocd/k8s/K8sClient.java
@@ -577,8 +577,8 @@ public class K8sClient {
     @NotNull
     private String getPVCName(Volume volume, @NotNull AutoCD autoCD) {
         // TODO: we should switch to an unhashed version for readability reasons - what is the best way to migrate the old porjects?
-//        var str = getNamespaceString() + "--" + getServiceName(autoCD) + "--" + "claim" + autoCD.getVolumes().indexOf(volume);
-//        return Util.slugify(str);
+        //var str = getNamespaceString() + "--" + getServiceName(autoCD) + "--" + "claim" + autoCD.getVolumes().indexOf(volume);
+        //return Util.slugify(str);
 
         var str = getNamespaceString() + "-" + getName() + "-" + autoCD.getIdentifierRegistryImagePath() + "-" + autoCD.getVolumes().indexOf(volume) + "-claim";
         return hash(str).substring(0, 20);

--- a/src/main/java/de/worldiety/autocd/util/Util.java
+++ b/src/main/java/de/worldiety/autocd/util/Util.java
@@ -51,7 +51,6 @@ public class Util {
         return hexString.toString();
     }
 
-
     public static String hash(String toHash) {
         MessageDigest digest = null;
         try {
@@ -63,5 +62,12 @@ public class Util {
                 toHash.getBytes(StandardCharsets.UTF_8));
 
         return Util.bytesToHex(encodedhash);
+    }
+
+    public static String slugify(String toSlug) {
+        if (toSlug == null) {
+            return null;
+        }
+        return toSlug.replaceAll("[^a-zA-Z\\-]", "").substring(0, Integer.min(toSlug.length(), 255));
     }
 }

--- a/src/main/java/de/worldiety/autocd/util/Util.java
+++ b/src/main/java/de/worldiety/autocd/util/Util.java
@@ -68,6 +68,7 @@ public class Util {
         if (toSlug == null) {
             return null;
         }
-        return toSlug.replaceAll("[^a-zA-Z\\-]", "").substring(0, Integer.min(toSlug.length(), 255));
+        String slugified = toSlug.replaceAll("[^a-zA-Z\\-]", "");
+        return slugified.substring(0, Integer.min(slugified.length(), 255));
     }
 }

--- a/src/main/java/de/worldiety/autocd/util/Util.java
+++ b/src/main/java/de/worldiety/autocd/util/Util.java
@@ -65,10 +65,14 @@ public class Util {
     }
 
     public static String slugify(String toSlug) {
+        return slugify(toSlug, 255);
+    }
+
+    public static String slugify(String toSlug, int maxLength) {
         if (toSlug == null) {
             return null;
         }
-        String slugified = toSlug.replaceAll("[^a-zA-Z\\-]", "");
-        return slugified.substring(0, Integer.min(slugified.length(), 255));
+        String slugified = toSlug.toLowerCase().replaceAll("[^a-z0-9\\-]", "");
+        return slugified.substring(0, Integer.min(slugified.length(), maxLength));
     }
 }


### PR DESCRIPTION
Hi,
I wanted to improve the readability of the Pods/Services etc. and skip the lookups of hashes when debugging or looking at the monitoring system.

I **did not** changed the `getPVCName` method, because that might break the StatefulSets, right!?

Do you think that we can use this as a drop in replacement or do the changes break a deployment?