### PR TITLE
Add support for Rust and Rocket

### DIFF
--- a/src/main/java/de/worldiety/autocd/docker/DockerfileHandler.java
+++ b/src/main/java/de/worldiety/autocd/docker/DockerfileHandler.java
@@ -90,6 +90,10 @@ public class DockerfileHandler {
         if ("go".equals(ext)) {
             return FileType.GO;
         } else if (".rs".equals(ext)) {
+            var rocketConfig = new File("Rocket.toml");
+            if (rocketConfig.isFile()) {
+                return FileType.RUST_ROCKET;
+            }
             return FileType.RUST;
         } else if ("java".equals(ext)) {
             return FileType.JAVA;

--- a/src/main/java/de/worldiety/autocd/docker/DockerfileHandler.java
+++ b/src/main/java/de/worldiety/autocd/docker/DockerfileHandler.java
@@ -1,17 +1,21 @@
 package de.worldiety.autocd.docker;
 
 import de.worldiety.autocd.util.FileType;
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
-
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 
 public class DockerfileHandler {
     private List<File> fileList = new ArrayList<>();

--- a/src/main/java/de/worldiety/autocd/docker/DockerfileHandler.java
+++ b/src/main/java/de/worldiety/autocd/docker/DockerfileHandler.java
@@ -1,21 +1,17 @@
 package de.worldiety.autocd.docker;
 
 import de.worldiety.autocd.util.FileType;
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStreamWriter;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IOUtils;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.*;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.NotNull;
 
 public class DockerfileHandler {
     private List<File> fileList = new ArrayList<>();
@@ -93,6 +89,8 @@ public class DockerfileHandler {
         //noinspection IfCanBeSwitch
         if ("go".equals(ext)) {
             return FileType.GO;
+        } else if (".rs".equals(ext)) {
+            return FileType.RUST;
         } else if ("java".equals(ext)) {
             return FileType.JAVA;
         } else if ("vue".equals(ext)) {

--- a/src/main/java/de/worldiety/autocd/k8s/K8sClient.java
+++ b/src/main/java/de/worldiety/autocd/k8s/K8sClient.java
@@ -868,7 +868,7 @@ public class K8sClient {
             return "local-default-name";
         }
 
-        return System.getenv(Environment.CI_PROJECT_NAME.toString()) + hyphenedBuildType;
+        return System.getenv(Environment.CI_PROJECT_NAME.toString().replace("_", "-")) + hyphenedBuildType;
     }
 
     @NotNull

--- a/src/main/java/de/worldiety/autocd/persistence/AutoCD.java
+++ b/src/main/java/de/worldiety/autocd/persistence/AutoCD.java
@@ -68,6 +68,7 @@ public class AutoCD {
                 return new AutoCD.Resources("0.075", "0.001", "400Mi", "250Mi");
             case GO:
             case RUST:
+            case RUST_ROCKET:
                 return new AutoCD.Resources("0.075", "0.001", "50Mi", "5Mi");
             case VUE:
             case NUXT:

--- a/src/main/java/de/worldiety/autocd/persistence/AutoCD.java
+++ b/src/main/java/de/worldiety/autocd/persistence/AutoCD.java
@@ -67,6 +67,7 @@ public class AutoCD {
             case JAVA:
                 return new AutoCD.Resources("0.075", "0.001", "400Mi", "250Mi");
             case GO:
+            case RUST:
                 return new AutoCD.Resources("0.075", "0.001", "50Mi", "5Mi");
             case VUE:
             case NUXT:

--- a/src/main/java/de/worldiety/autocd/util/FileType.java
+++ b/src/main/java/de/worldiety/autocd/util/FileType.java
@@ -8,6 +8,7 @@ public enum FileType {
     VUE("vue", "vue-builder", "vue-prod", "RUN npm run build\n"),
     NUXT("vue", "nuxt-builder", "nuxt-prod", "RUN npm i && npm run build"),
     EISEN("eisen", "vue-builder", "vue-prod", "RUN npm run build\n"),
+    RUST("rust", "rust-builder", "rust-prod", "rust-autocd-builder ."),
     OTHER("other");
 
     private final String name;

--- a/src/main/java/de/worldiety/autocd/util/FileType.java
+++ b/src/main/java/de/worldiety/autocd/util/FileType.java
@@ -8,7 +8,8 @@ public enum FileType {
     VUE("vue", "vue-builder", "vue-prod", "RUN npm run build\n"),
     NUXT("vue", "nuxt-builder", "nuxt-prod", "RUN npm i && npm run build"),
     EISEN("eisen", "vue-builder", "vue-prod", "RUN npm run build\n"),
-    RUST("rust", "rust-builder", "rust-prod", "rust-autocd-builder ."),
+    RUST("rust", "rust-builder", "rust-prod", "RUN rust-autocd-builder ."),
+    RUST_ROCKET("rust", "rust-builder", "rust-rocket-prod", "RUN rust-autocd-builder ."),
     OTHER("other");
 
     private final String name;

--- a/src/main/resources/rust-builder
+++ b/src/main/resources/rust-builder
@@ -1,0 +1,5 @@
+FROM fredlahde/rust-autocd-builder as builder
+
+WORKDIR /app
+COPY . .
+

--- a/src/main/resources/rust-prod
+++ b/src/main/resources/rust-prod
@@ -1,0 +1,5 @@
+FROM alpine:latest
+
+COPY --from=builder /app/app app
+
+CMD ["./app"]

--- a/src/main/resources/rust-rocket-prod
+++ b/src/main/resources/rust-rocket-prod
@@ -1,0 +1,6 @@
+FROM ubuntu:latest
+
+COPY --from=builder /app/app app
+COPY --from=builder /app/Rocket.toml Rocket.toml
+
+CMD ["./app"]


### PR DESCRIPTION
No deployment tool is complete without support for real programming languages 😈

Jokes aside, this PR adds support for nightly [Rust](https://www.rust-lang.org/) and the [Rocket](https://rocket.rs/) Webframework.

Two new `Filetype`s where added:

- `RUST` - nightly Rust, built with help of [this](https://github.com/fredlahde/rust-autocd-builder) tool. Said tool compiles a release build and copies it into `./app` to adhere to the AutoCD standards. AFAIK this is not possible with cargo
- `RUST_ROCKET` - Inherits everything from `RUST`, but also copies a `Rocket.toml` file, which is Rockets global configuration into the prod container, and the prod container is based upon Ubuntu instead of alpine, because Rocket links to a few shared objects which are not shipped with alpine by default

A note about nightly Rust:
I never used stable Rust for anything, ever. I have yet to face a stability problem with it. In addition, Rocket requires at least beta Rust. I think it'd be possible to default to stable for `RUST` and beta for `RUST_ROCKET` and make nightly an opt-in. I'll leave this open for discussion.

As for resource limits, I decided to use those assigned to the `GO` type for now

Let me hear what you think!
