### PR TITLE
Add support for Rust and Rocket

### DIFF
--- a/src/main/java/de/worldiety/autocd/docker/DockerfileHandler.java
+++ b/src/main/java/de/worldiety/autocd/docker/DockerfileHandler.java
@@ -93,6 +93,12 @@ public class DockerfileHandler {
         //noinspection IfCanBeSwitch
         if ("go".equals(ext)) {
             return FileType.GO;
+        } else if (".rs".equals(ext)) {
+            var rocketConfig = new File("Rocket.toml");
+            if (rocketConfig.isFile()) {
+                return FileType.RUST_ROCKET;
+            }
+            return FileType.RUST;
         } else if ("java".equals(ext)) {
             return FileType.JAVA;
         } else if ("vue".equals(ext)) {

--- a/src/main/java/de/worldiety/autocd/persistence/AutoCD.java
+++ b/src/main/java/de/worldiety/autocd/persistence/AutoCD.java
@@ -67,6 +67,8 @@ public class AutoCD {
             case JAVA:
                 return new AutoCD.Resources("0.075", "0.001", "400Mi", "250Mi");
             case GO:
+            case RUST:
+            case RUST_ROCKET:
                 return new AutoCD.Resources("0.075", "0.001", "50Mi", "5Mi");
             case VUE:
             case NUXT:

--- a/src/main/java/de/worldiety/autocd/util/FileType.java
+++ b/src/main/java/de/worldiety/autocd/util/FileType.java
@@ -8,6 +8,8 @@ public enum FileType {
     VUE("vue", "vue-builder", "vue-prod", "RUN npm run build\n"),
     NUXT("vue", "nuxt-builder", "nuxt-prod", "RUN npm i && npm run build"),
     EISEN("eisen", "vue-builder", "vue-prod", "RUN npm run build\n"),
+    RUST("rust", "rust-builder", "rust-prod", "RUN rust-autocd-builder ."),
+    RUST_ROCKET("rust", "rust-builder", "rust-rocket-prod", "RUN rust-autocd-builder ."),
     OTHER("other");
 
     private final String name;

--- a/src/main/resources/rust-builder
+++ b/src/main/resources/rust-builder
@@ -1,0 +1,5 @@
+FROM fredlahde/rust-autocd-builder as builder
+
+WORKDIR /app
+COPY . .
+

--- a/src/main/resources/rust-prod
+++ b/src/main/resources/rust-prod
@@ -1,0 +1,5 @@
+FROM alpine:latest
+
+COPY --from=builder /app/app app
+
+CMD ["./app"]

--- a/src/main/resources/rust-rocket-prod
+++ b/src/main/resources/rust-rocket-prod
@@ -1,0 +1,6 @@
+FROM ubuntu:latest
+
+COPY --from=builder /app/app app
+COPY --from=builder /app/Rocket.toml Rocket.toml
+
+CMD ["./app"]


### PR DESCRIPTION
No deployment tool is complete without support for real programming languages 😈

Jokes aside, this PR adds support for nightly [Rust](https://www.rust-lang.org/) and the [Rocket](https://rocket.rs/) Webframework.

Two new `Filetype`s where added:

- `RUST` - nightly Rust, built with help of [this](https://github.com/fredlahde/rust-autocd-builder) tool. Said tool compiles a release build and copies it into `./app` to adhere to the AutoCD standards. AFAIK this is not possible with cargo
- `RUST_ROCKET` - Inherits everything from `RUST`, but also copies a `Rocket.toml` file, which is Rockets global configuration into the prod container, and the prod container is based upon Ubuntu instead of alpine, because Rocket links to a few shared objects which are not shipped with alpine by default

A note about nightly Rust:
I never used stable Rust for anything, ever. I have yet to face a stability problem with it. In addition, Rocket requires at least beta Rust. I think it'd be possible to default to stable for `RUST` and beta for `RUST_ROCKET` and make nightly an opt-in. I'll leave this open for discussion.

As for resource limits, I decided to use those assigned to the `GO` type for now

Let me hear what you think!
