### PR TITLE
add buildtype to docker build args

### DIFF
--- a/src/main/java/de/worldiety/autocd/docker/Docker.java
+++ b/src/main/java/de/worldiety/autocd/docker/Docker.java
@@ -68,6 +68,7 @@ public class Docker {
 
         client.buildImageCmd(configFile)
                 .withTags(Set.of(tag))
+                .withBuildArg("buildType", buildType)
                 .exec(callback)
                 .awaitImageId();
 


### PR DESCRIPTION
This PR adds the buildtype as a build arg to the Dockerfile that is built, this is done so configuration can be managed for separate types.